### PR TITLE
Allow mouse middle click to close tab

### DIFF
--- a/src/ui/directives/tabView/tabViewCtrl.js
+++ b/src/ui/directives/tabView/tabViewCtrl.js
@@ -48,6 +48,8 @@ angular.module('app').controller('tabViewCtrl', [
     $scope.activateTab = function(tab, $event) {
       if ($event) $event.preventDefault();
 
+      if ($event.button === 1) return $scope.closeTab(tab, $event);
+
       if (tab.active) return;
       else {
         tabCache.deactivateAll();


### PR DESCRIPTION
Enables middle clicking to close a tab. More of a PC feature than OSX as middle click is usually only possible with a mouse that has a scroll wheel (push down on the wheel and it triggers a modified click event that you can detect). Some mac software allows you to set 3 finger click to function similar to that.

Most browsers, Sublime Text and various other software that use tabs tend to have this feature.

Resolves officert/mongotron#26