### PR TITLE
Using the bower executable inside node_modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ A Mongo DB GUI built using Electron, and Angular Js.
 npm install
 ```
 ```shell
-bower install
+./node_modules/.bin/bower install
 ```
 
 * Install gulp globally


### PR DESCRIPTION
I don't think everyone has bower installed globally, so it would be more preferable to use the executable that's already downloaded in the node_module folder.