### PR TITLE
Load package.json without blowing up

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -216,8 +216,8 @@ gulp.task('prod-sym-links', ['remove-link-src', 'remove-link-lib'], () => {
 });
 
 gulp.task('dev-sym-links', ['remove-link-src', 'remove-link-lib', 'remove-link-tests'], () => {
-  return gulp.src(['src/', 'src/lib/', 'tests/'])
-    .pipe(symlink(['./node_modules/src', './node_modules/lib', './node_modules/tests'], {
+  return gulp.src(['src/', 'src/lib/', 'tests/', 'package.json'])
+    .pipe(symlink(['./node_modules/src', './node_modules/lib', './node_modules/tests', './node_modules/package.json'], {
       force: true
     }));
 });

--- a/src/config/appConfig.js
+++ b/src/config/appConfig.js
@@ -4,14 +4,7 @@
 var _ = require('underscore');
 var path = require('path-extra');
 
-// var packageJson = require('../../package.json');
-var packageJson = {
-  version: '1.0.0-alpha.1',
-  name: 'Mongotron',
-  repository: {
-    url: 'https://github.com/mongotron'
-  }
-};
+var packageJson = require('../../package.json');
 
 /* =========================================================================
  * App Config Settings


### PR DESCRIPTION
I added `package.json` to the symlink task during build to resolve this. `package.json` is loaded from the `node_modules/src/config/` directory so `'../../'` was only making it to the `node_modules` directory.

#45 