### PR TITLE
[WIP] Adds table view

### DIFF
--- a/src/lib/modules/expression/index.js
+++ b/src/lib/modules/expression/index.js
@@ -17,7 +17,7 @@ class Expression {
    * @param {Object} [scope] - a customized scope that the expression will be evaluated in
    * @returns Promise
    */
-  eval(expression, scope) {
+  evaluate(expression, scope) {
     return new Promise((resolve, reject) => {
       if (!expression) return reject(new Error('Expression - eval() - expression is required'));
 

--- a/src/ui/directives/inlineEditor/inlineEditorCtrl.js
+++ b/src/ui/directives/inlineEditor/inlineEditorCtrl.js
@@ -46,7 +46,7 @@ angular.module('app').controller('inlineEditorCtrl', [
         doc: $scope.doc
       };
 
-      expression.eval($scope.newValue, evalScope)
+      expression.evaluate($scope.newValue, evalScope)
         .then(expressionResult => {
           let updates = {};
           updates[$scope.inlineEditorKey] = expressionResult.result;

--- a/src/ui/directives/query/query.html
+++ b/src/ui/directives/query/query.html
@@ -29,6 +29,10 @@
           tooltip-placement="bottom" tooltip-popup-delay="800" tooltip-append-to-body="true">
           <i class="fa fa-bars"></i>
         </button>
+        <button type="button" class="btn btn-default btn-sm" ng-disabled="!resultMongoMethodName || resultMongoMethodName === 'count'" ng-click="currentView = VIEWS.TABLE" ng-class="{ active : currentView === VIEWS.TABLE }" uib-tooltip="Table View"
+          tooltip-placement="bottom" tooltip-popup-delay="800" tooltip-append-to-body="true">
+          <i class="fa fa-table"></i>
+        </button>
       </div>
       <div class="btn-group">
         <button type="button" class="btn btn-default btn-sm" ng-click="collapseAll()" ng-disabled="currentView !== VIEWS.KEYVALUE" uib-tooltip="Collapse All" tooltip-placement="bottom" tooltip-popup-delay="800" tooltip-append-to-body="true">
@@ -106,6 +110,22 @@
                   <key-value-result result="result" result-original="result.original"></key-value-result>
                 </div>
               </div>
+            </div>
+          </div>
+          <div class="query-results" ng-if="currentView === VIEWS.TABLE && !loading">
+            <div class="table-view">
+              <table class="table table-condensed">
+                <thead>
+                <tr>
+                  <th ng-repeat="field in fields">{{ field }}</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr class="result-row" ng-repeat="doc in result">
+                  <td class="result-cell" title="{{ doc[field] }}" ng-repeat="field in fields">{{ doc[field] }}</td>
+                </tr>
+                </tbody>
+              </table>
             </div>
           </div>
         </div>

--- a/src/ui/directives/query/queryCtrl.js
+++ b/src/ui/directives/query/queryCtrl.js
@@ -87,6 +87,7 @@ angular.module('app').controller('queryCtrl', [
     $scope.VIEWS = {
       TEXT: 'TEXT',
       KEYVALUE: 'KEYVALUE',
+      TABLE: 'TABLE',
       RAW: 'RAW'
     };
     $scope.currentView = $scope.VIEWS.KEYVALUE;
@@ -133,6 +134,7 @@ angular.module('app').controller('queryCtrl', [
         .then(expressionResult => {
           $scope.$apply(() => {
             $scope.result = expressionResult.result;
+            $scope.fields = _getFields(expressionResult.result);
             $scope.resultMongoMethodName = expressionResult.mongoMethodName;
             $scope.queryTime = expressionResult.time;
             $scope.keyValueResults = expressionResult.keyValueResults || [];
@@ -226,6 +228,12 @@ angular.module('app').controller('queryCtrl', [
             $scope.loading = false;
           });
         });
+    }
+
+    function _getFields(documents) {
+      if (!Array.isArray(documents)) 
+        return [];
+      return Object.keys(Object.assign(...documents));
     }
   }
 ]);

--- a/src/ui/directives/query/queryCtrl.js
+++ b/src/ui/directives/query/queryCtrl.js
@@ -130,7 +130,7 @@ angular.module('app').controller('queryCtrl', [
 
       let evalScope = _createEvalScopeFromCollections($scope.database.collections);
 
-      expression.eval(rawExpression, evalScope)
+      expression.evaluate(rawExpression, evalScope)
         .then(expressionResult => {
           $scope.$apply(() => {
             $scope.result = expressionResult.result;

--- a/src/ui/directives/queryResultsExport/queryResultsExportCtrl.js
+++ b/src/ui/directives/queryResultsExport/queryResultsExportCtrl.js
@@ -103,7 +103,7 @@ angular.module('app').controller('queryResultsExportCtrl', [
 
           let evalScope = _createEvalScopeFromCollections(activeTab.database.collections);
 
-          expression.eval($scope.query, evalScope)
+          expression.evaluate($scope.query, evalScope)
             .then(expressionResult => {
               if (!expressionResult.mongoMethodName) {
                 notificationService.error('Cannot export a non MongoDb expression');

--- a/src/ui/less/components/queryResultViews.less
+++ b/src/ui/less/components/queryResultViews.less
@@ -94,3 +94,25 @@
     }
   }
 }
+.table-view {
+  .query-result-view();
+  
+  .result-row {
+    background: @theme-query-result-json-bg;
+    &:nth-child(even) {
+      background: darken(@theme-query-result-json-bg, 4%);
+    }
+  }
+  
+  .result-cell {
+    white-space: nowrap;
+    max-width: 300px; 
+    text-overflow: ellipsis; 
+    overflow: hidden;
+    border: 0;
+  }
+
+  .table th {
+    border: 0;
+  }
+}

--- a/tests/unit/modules/expression/eval-test.js
+++ b/tests/unit/modules/expression/eval-test.js
@@ -26,7 +26,7 @@ describe('modules', () => {
         let expr = null;
 
         it('should reject with an error', next => {
-          expression.eval(expr)
+          expression.evaluate(expr)
             .catch(error => {
 
               should.exist(error);
@@ -43,7 +43,7 @@ describe('modules', () => {
         let expectedEvalResult = 3;
 
         it('should return an expression result object', next => {
-          expression.eval(expr)
+          expression.evaluate(expr)
             .then(expressionResult => {
 
               should.exist(expressionResult);
@@ -60,7 +60,7 @@ describe('modules', () => {
         let expectedEvalResult = 'hello';
 
         it('should return an expression result object', next => {
-          expression.eval(expr)
+          expression.evaluate(expr)
             .then(expressionResult => {
 
               should.exist(expressionResult);
@@ -77,7 +77,7 @@ describe('modules', () => {
         let expectedEvalResult = 'foo is not defined';
 
         it('should reject with an error', next => {
-          expression.eval(expr)
+          expression.evaluate(expr)
             .catch(error => {
 
               should.exist(error);
@@ -96,7 +96,7 @@ describe('modules', () => {
         let expectedEvalResult = 12345;
 
         it('should return an expression result object', next => {
-          expression.eval(expr, evalScope)
+          expression.evaluate(expr, evalScope)
             .then(expressionResult => {
 
               should.exist(expressionResult);
@@ -117,7 +117,7 @@ describe('modules', () => {
         let expectedEvalResult = 12345;
 
         it('should return an expression result object', next => {
-          expression.eval(expr, evalScope)
+          expression.evaluate(expr, evalScope)
             .then(expressionResult => {
 
               should.exist(expressionResult);


### PR DESCRIPTION
This adds a table view to the query page. It iterates over the resultset to find all unique fields. Merge it if you feel it is good enough. I mainly created a PR now to get some general input however before going further. 

Also, the table view is currently not doing any fancy formatting of the results as the key value view does. I'd like to add that, but think it would be good to reuse the code in `keyValueUtils.js`. How about renaming and maybe generalize it somewhat into `queryResultParser.js`?

Will also add edit and remove buttons similar to the key value view.

Related feature request #122 