### PR TITLE
Remove check that _id is an instance of ObjectID

### DIFF
--- a/src/lib/entities/collection.js
+++ b/src/lib/entities/collection.js
@@ -170,7 +170,6 @@ class Collection {
     return new Promise((resolve, reject) => {
       if (!objectId) return reject(new errors.InvalidArugmentError('objectId is required'));
       if (!updates) return reject(new errors.InvalidArugmentError('updates is required'));
-      if (!mongoUtils.isObjectId(objectId)) return reject(new errors.InvalidArugmentError('objectId must be an instance of ObjectId'));
       options = options || {};
 
       this._dbCollection.updateOne({


### PR DESCRIPTION
This removes a check that `_id` is an instance of `ObjectID`. My understanding when reading the [docs](https://docs.mongodb.org/manual/reference/object-id/) is that the `_id` is recommended to be an ObjectId, but that it is not required. When I tested with a database for [parse-server](https://github.com/ParsePlatform/parse-server) (which uses strings as _id), updates to documents failed with  the following error `InvalidArugmentError('objectId must be an instance of ObjectId');`. With the check removed it worked perfectly.